### PR TITLE
add support for VIP slogans

### DIFF
--- a/gts/pokemondpds_web.ashx.cs
+++ b/gts/pokemondpds_web.ashx.cs
@@ -126,10 +126,9 @@ namespace PkmnFoundations.GTS
                     // todo: keep VIPs in database
                     response.Write(new byte[] { 0x00, 0x00, 0x00, 0x00 }, 0, 4);
                     // VIPs.
-                    foreach (var id in VIPIds)
+                    foreach (var vip in VIPs)
                     {
-                        response.Write(BitConverter.GetBytes(id), 0, 4);
-                        response.Write(new byte[] { 0x00, 0x00, 0x00, 0x00 }, 0, 4);
+                        response.Write(vip.Save(), 0, vip.Size);
                     }
                 }
                 break;
@@ -261,10 +260,27 @@ namespace PkmnFoundations.GTS
         /// <summary>
         /// The list of "VIPs".
         ///
-        /// Being a VIP in a lobby just gives you a golden trainer card, and upgrades your 'Touch Toy' to the highest
-        /// level right away. So far we've just been giving this to the developers who signed up for it.
+        /// Being a VIP gives you the following benefits:
+        ///
+        /// 1. Your Tap Toy is immediately upgraded to level 3.
+        /// 2. You get a gold trainer card, instead of a blue trainer card.
+        /// 3. You get a special color on the list of people in a lobby.
+        /// 4. You get a special color name on the footprint board.
+        /// 5. Some other mini games have a special color for your name.
+        ///
+        /// VIPs can also have custom "passphrases" that show when you bump
+        /// into them. These are generated from the standard word list you
+        /// could choose in any word box. These will show when you bump into
+        /// a user.
         /// </summary>
-        private static int[] VIPIds = new int[] { 600403373, 601315647, 601988829 };
+        private static VipRecord[] VIPs = new VipRecord[] {
+            new VipRecord(600403373, 0, 0, 0, 0),
+            new VipRecord(601315647, 0, 0, 0, 0),
+            new VipRecord(601988829, 0, 0, 0, 0),
+            new VipRecord(602778198, 4, 4, 4, 4), // "STEEL STEEL STEEL STEEL"
+            // Etchy -- for finding vips in the first place.
+            new VipRecord(602778716, 0, 0, 0, 0)
+        };
 
         /// <summary>
         /// A static questionnaire, who's id is not above 1k so it doesn't load the custom question text.

--- a/library/Wfc/VipRecord.cs
+++ b/library/Wfc/VipRecord.cs
@@ -1,0 +1,76 @@
+using PkmnFoundations.Support;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace PkmnFoundations.Wfc
+{
+    public class VipRecord : BinarySerializableBase
+    {
+        public VipRecord()
+        {
+          Pid = 0;
+          WordPartA = 0;
+          WordPartB = 0;
+          WordPartC = 0;
+          WordPartD = 0;
+        }
+
+        public VipRecord(uint pid)
+        {
+          Pid = pid;
+          WordPartA = 0;
+          WordPartB = 0;
+          WordPartC = 0;
+          WordPartD = 0;
+        }
+
+        public VipRecord(uint pid, byte wordA, byte wordB, byte wordC, byte wordD)
+        {
+            Pid = pid;
+            WordPartA = wordA;
+            WordPartB = wordB;
+            WordPartC = wordC;
+            WordPartD = wordD;
+        }
+
+        public VipRecord(byte[] data)
+        {
+            Load(data);
+        }
+
+        public uint Pid; // Profile id of the user who is a VIP.
+        public byte WordPartA; // D + A creates first word, A + B creates second word.
+        public byte WordPartB; // A + B creates second word, B + C creates third word.
+        public byte WordPartC; // B + C creates third word, C + D creates fourth word.
+        public byte WordPartD; // D + A creates first word, C + D creates fourth word.
+
+        protected override void Load(BinaryReader reader)
+        {
+            Pid = reader.ReadUInt32();
+            WordPartA = reader.ReadByte();
+            WordPartB = reader.ReadByte();
+            WordPartC = reader.ReadByte();
+            WordPartD = reader.ReadByte();
+        }
+
+        protected override void Save(BinaryWriter writer)
+        {
+            writer.Write(Pid);
+            writer.Write(WordPartA);
+            writer.Write(WordPartB);
+            writer.Write(WordPartC);
+            writer.Write(WordPartD);
+        }
+
+        public override int Size
+        {
+            get
+            {
+                return 8;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Slogans/Passphrases, originally discovered by
[Etchy](https://www.youtube.com/@Etch), while researching a video were a system used when the service was online. VIPs were only effectively used in japan, and only in small scale. Not being talked much here in the US. Huge props to Etchy for finding out about them, but also finding out about Slogans.

Slogans were used as a "password" like system, where players would take a 4 letter passphrase to a place in the real world (eugh), and then would presumably get something.

for now we're keeping most people with no vip records, and i added a temp pid of mine, and assigned it 4 words of my favorite type STEEL. I've also added an account of etchy's for a thank you as figuring this all out.

Creating a full builder type for words, is something I'm not quite clear on how to build in a way that isn't terrible. We can build out later, i did document at the very least how it works.